### PR TITLE
get_den_si: API removed, update support.py

### DIFF
--- a/islplot/support.py
+++ b/islplot/support.py
@@ -23,7 +23,7 @@ def _vertex_to_rational_point(vertex):
     for i in range(expr.dim(dim_type.out)):
         subexpr = expr.get_aff(i)
         val = subexpr.get_constant_val()
-        value.append((val.get_num_si(), val.get_den_si()))
+        value.append((val.get_num_si(), val.get_den_val().to_python()))
 
     return value
 


### PR DESCRIPTION
The get_den_si API is no longer generated by the islpy binding-generator,
because it finds an equivalent _val version. Basic things like plot_bset_shapes
was broken due to this missing API.

Signed-off-by: Ramkumar Ramachandra <artagnon@gmail.com>